### PR TITLE
[registration-handler] Добавлен обработчик регистрации

### DIFF
--- a/packages/client/src/pages/registration/api.ts
+++ b/packages/client/src/pages/registration/api.ts
@@ -1,0 +1,17 @@
+import { TRegisterData, TRegisterOkResponse } from '@pages/registration/types';
+import { fetchApi } from '@utils/fetchApi';
+
+export async function signUp(
+    data: TRegisterData,
+    opts?: { signal?: AbortSignal }
+): Promise<TRegisterOkResponse> {
+    const res = await fetchApi<TRegisterOkResponse>('/auth/signup', {
+        method: 'POST',
+        data: data,
+        signal: opts?.signal,
+    });
+    if (!res || typeof res !== 'object' || !res.id) {
+        throw new Error('Invalid data received');
+    }
+    return res;
+}

--- a/packages/client/src/pages/registration/registration.tsx
+++ b/packages/client/src/pages/registration/registration.tsx
@@ -1,14 +1,54 @@
 import { Form } from '@components/form';
 import { Page } from '@components/page';
+import { ROUTES } from '@constants/routes';
+import { useNotification } from '@hooks/useNotification';
+import { useProfile } from '@hooks/useProfile';
 import { Grid, Link } from '@mui/material';
+import { ApiError } from '@utils/fetchApi';
+import { useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 
+import { signUp } from './api';
 import { REGISTRATION_INPUTS, REGISTRATION_SCHEMA } from './constants';
 import styles from './styles.module.scss';
 
 const RegistrationPage = () => {
-    const handleSubmit = (data: Record<string, string | File | null>) => {
-        // Отсюда обращения к API регистрации, пока не реализовано - console.log
-        console.log(data);
+    const { showError, showSuccess } = useNotification();
+    const controllerRef = useRef<AbortController | null>(null);
+    const navigate = useNavigate();
+    const { getUserData } = useProfile();
+
+    const handleSubmit = async (data: Record<string, string | File | null>) => {
+        const payload = {
+            first_name: (data.first_name as string) || '',
+            second_name: (data.second_name as string) || '',
+            login: (data.login as string) || '',
+            email: (data.email as string) || '',
+            password: (data.password as string) || '',
+            phone: (data.phone as string) || '',
+        };
+        controllerRef.current = new AbortController();
+        try {
+            const response = await signUp(payload, {
+                signal: controllerRef.current.signal,
+            });
+            if (response.id) {
+                await getUserData();
+                navigate(ROUTES.PROFILE);
+                showSuccess('Успешная регистрация');
+            }
+        } catch (error) {
+            if (error instanceof ApiError && error.status === 409) {
+                if (error.data.reason === 'Login already exists') {
+                    showError('Логин уже занят');
+                    return;
+                } else if (error.data.reason === 'Email already exists') {
+                    showError('Email уже занят');
+                    return;
+                }
+            }
+            showError('Ошибка регистрации');
+        }
     };
     return (
         <Page>

--- a/packages/client/src/pages/registration/types.ts
+++ b/packages/client/src/pages/registration/types.ts
@@ -1,0 +1,12 @@
+export type TRegisterData = {
+    first_name: string;
+    second_name: string;
+    login: string;
+    email: string;
+    password: string;
+    phone: string;
+};
+
+export type TRegisterOkResponse = {
+    id: number;
+};


### PR DESCRIPTION
### Какую задачу решаем
Добавить обработчик регистрации.

### Скриншоты/видяшка (если есть)

### TBD (если есть).
Немного переделал fetchApi, чтобы он отдавал текст и статус ошибок из API, чтобы можно было указать при регистрации, что логин/email занят.
И еще, заметил, что как-то странно работает API Yandex'а. Почему-то по ручке POST /auth/signup в поле second_name всегда после успешной регистрации возвращается с api только первая буква фамилии :)